### PR TITLE
Make pebble write options configurable

### DIFF
--- a/datastore.go
+++ b/datastore.go
@@ -21,11 +21,12 @@ var logger = log.Logger("pebble")
 type Datastore struct {
 	db *pebble.DB
 
-	cache      *pebble.Cache
-	closing    chan struct{}
-	disableWAL bool
-	status     int32
-	wg         sync.WaitGroup
+	cache        *pebble.Cache
+	closing      chan struct{}
+	disableWAL   bool
+	status       int32
+	writeOptions *pebble.WriteOptions
+	wg           sync.WaitGroup
 }
 
 var _ ds.Datastore = (*Datastore)(nil)
@@ -60,11 +61,17 @@ func NewDatastore(path string, options ...Option) (*Datastore, error) {
 		}
 	}
 
+	writeOptions := pebble.NoSync
+	if opts.pebbleWriteOptions != nil {
+		writeOptions = opts.pebbleWriteOptions
+	}
+
 	return &Datastore{
-		db:         db,
-		disableWAL: disableWAL,
-		cache:      cache,
-		closing:    make(chan struct{}),
+		db:           db,
+		disableWAL:   disableWAL,
+		cache:        cache,
+		writeOptions: writeOptions,
+		closing:      make(chan struct{}),
 	}, nil
 }
 
@@ -304,7 +311,7 @@ func (d *Datastore) Query(ctx context.Context, q query.Query) (query.Results, er
 }
 
 func (d *Datastore) Put(ctx context.Context, key ds.Key, value []byte) error {
-	err := d.db.Set(key.Bytes(), value, pebble.NoSync)
+	err := d.db.Set(key.Bytes(), value, d.writeOptions)
 	if err != nil {
 		return fmt.Errorf("pebble error during set: %w", err)
 	}
@@ -321,7 +328,7 @@ func (d *Datastore) DiskUsage(ctx context.Context) (uint64, error) {
 }
 
 func (d *Datastore) Delete(ctx context.Context, key ds.Key) error {
-	err := d.db.Delete(key.Bytes(), pebble.NoSync)
+	err := d.db.Delete(key.Bytes(), d.writeOptions)
 	if err != nil {
 		return fmt.Errorf("pebble error during delete: %w", err)
 	}
@@ -346,7 +353,10 @@ func (d *Datastore) Sync(ctx context.Context, _ ds.Key) error {
 }
 
 func (d *Datastore) Batch(ctx context.Context) (ds.Batch, error) {
-	return &Batch{d.db.NewBatch()}, nil
+	return &Batch{
+		batch:        d.db.NewBatch(),
+		writeOptions: d.writeOptions,
+	}, nil
 }
 
 func (d *Datastore) Close() error {
@@ -397,13 +407,14 @@ func (d *Datastore) inefficientOrderQuery(ctx context.Context, q query.Query, ba
 }
 
 type Batch struct {
-	batch *pebble.Batch
+	batch        *pebble.Batch
+	writeOptions *pebble.WriteOptions
 }
 
 var _ ds.Batch = (*Batch)(nil)
 
 func (b *Batch) Put(ctx context.Context, key ds.Key, value []byte) error {
-	err := b.batch.Set(key.Bytes(), value, pebble.NoSync)
+	err := b.batch.Set(key.Bytes(), value, b.writeOptions)
 	if err != nil {
 		return fmt.Errorf("pebble error during set within batch: %w", err)
 	}
@@ -411,7 +422,7 @@ func (b *Batch) Put(ctx context.Context, key ds.Key, value []byte) error {
 }
 
 func (b *Batch) Delete(ctx context.Context, key ds.Key) error {
-	err := b.batch.Delete(key.Bytes(), pebble.NoSync)
+	err := b.batch.Delete(key.Bytes(), b.writeOptions)
 	if err != nil {
 		return fmt.Errorf("pebble error during delete within batch: %w", err)
 	}
@@ -419,5 +430,5 @@ func (b *Batch) Delete(ctx context.Context, key ds.Key) error {
 }
 
 func (b *Batch) Commit(ctx context.Context) error {
-	return b.batch.Commit(pebble.NoSync)
+	return b.batch.Commit(b.writeOptions)
 }

--- a/datastore_test.go
+++ b/datastore_test.go
@@ -18,7 +18,7 @@ func TestPebbleDatastore(t *testing.T) {
 	dstest.SubtestAll(t, ds)
 }
 
-func newDatastore(t *testing.T) (*Datastore, func()) {
+func newDatastore(t *testing.T, options ...Option) (*Datastore, func()) {
 	t.Helper()
 
 	path, err := os.MkdirTemp(os.TempDir(), "testing_pebble_")
@@ -26,7 +26,7 @@ func newDatastore(t *testing.T) (*Datastore, func()) {
 		t.Fatal(err)
 	}
 
-	d, err := NewDatastore(path)
+	d, err := NewDatastore(path, options...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,4 +109,42 @@ func testDatastore(t *testing.T, ds *Datastore) {
 	if !bytes.Equal(v, val) {
 		t.Error("not equal", string(val))
 	}
+}
+
+func TestPebbleWriteOptions(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		dstore, cleanup := newDatastore(t)
+		defer cleanup()
+
+		if dstore.writeOptions != pebble.NoSync {
+			t.Fatalf("incorrect write options: expected %v, got %v", pebble.NoSync, dstore.writeOptions)
+		}
+
+		batch, err := dstore.Batch(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if batch.(*Batch).writeOptions != pebble.NoSync {
+			t.Fatalf("incorrect batch write options: expected %v, got %v", pebble.NoSync, batch.(*Batch).writeOptions)
+		}
+	})
+
+	t.Run("pebble.Sync", func(t *testing.T) {
+		dstore, cleanup := newDatastore(t, WithPebbleWriteOptions(pebble.Sync))
+		defer cleanup()
+
+		if dstore.writeOptions != pebble.Sync {
+			t.Fatalf("incorrect write options: expected %v, got %v", pebble.Sync, dstore.writeOptions)
+		}
+
+		batch, err := dstore.Batch(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if batch.(*Batch).writeOptions != pebble.Sync {
+			t.Fatalf("incorrect batch write options: expected %v, got %v", pebble.Sync, batch.(*Batch).writeOptions)
+		}
+	})
 }

--- a/option.go
+++ b/option.go
@@ -5,9 +5,10 @@ import (
 )
 
 type config struct {
-	cacheSize  int64
-	db         *pebble.DB
-	pebbleOpts *pebble.Options
+	cacheSize          int64
+	db                 *pebble.DB
+	pebbleOpts         *pebble.Options
+	pebbleWriteOptions *pebble.WriteOptions
 }
 
 type Option func(*config)
@@ -44,5 +45,13 @@ func WithPebbleDB(db *pebble.DB) Option {
 func WithPebbleOpts(opts *pebble.Options) Option {
 	return func(c *config) {
 		c.pebbleOpts = opts
+	}
+}
+
+// WithPebbleWriteOptions configures the write options for the datastore. If
+// not set, pebble.NoSync is used.
+func WithPebbleWriteOptions(opts *pebble.WriteOptions) Option {
+	return func(c *config) {
+		c.pebbleWriteOptions = opts
 	}
 }


### PR DESCRIPTION
Copy of https://github.com/ipfs/go-ds-pebble/pull/63

This branch is forked from `v0.5.0` which is what we are using on `onflow/flow-go` currently in `v0.43`